### PR TITLE
Add documentation for verifying courtesy digests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ This repository is intended as a starting point for the **GR‑11X‑MRL‑A1** 
 
 1. Follow the steps in `docs/SEALING_INSTRUCTIONS.md` to generate a protocol‑only BangCheck block using your preferred tool (e.g. the Cosmic Sealer web app).
 2. Store the resulting BangCheck in `annex/BANGCHECK.txt` and append a corresponding line to your annex ledger (`ANNEX_LEDGER_YYYY‑MM‑DD.md`).
-3. Optionally compute courtesy digests using `scripts/verify_hashes.py` and save them as a JSON sidecar next to the sealed artifact.
+3. Optionally compute courtesy digests using `scripts/verify_hashes.py` and save them as a JSON sidecar next to the sealed artifact. See `docs/HASH_VERIFICATION.md` for a step-by-step guide and automation tips.
 
 See the documentation and schemas for details on the field meanings and how to use CSL‑Plus and CSP‑RK in future releases.

--- a/docs/HASH_VERIFICATION.md
+++ b/docs/HASH_VERIFICATION.md
@@ -1,0 +1,51 @@
+# Hash Verification Guide
+
+This guide explains how to use the `scripts/verify_hashes.py` helper to compute
+and persist courtesy digests for artifacts that you seal with the Cosmic Seal
+Layer (CSL).
+
+## Prerequisites
+
+* Python 3.8 or newer.
+* Read access to the artifact you want to verify.
+
+## Basic Usage
+
+Run the script with the path to the artifact:
+
+```bash
+python3 scripts/verify_hashes.py /path/to/artifact.bin
+```
+
+The command prints SHA-256, SHA-384, and SHA-512 digests to the terminal and
+writes a JSON sidecar next to the source file (for example,
+`artifact.bin.digests.json`).
+
+## Automating Courtesy Digests
+
+You can call the module from another Python tool to integrate digest creation
+into your sealing workflow:
+
+```python
+from scripts.verify_hashes import compute_digests
+
+with open("artifact.bin", "rb") as fh:
+    # compute_digests expects a filesystem path; adjust as needed if you stage
+    # artifacts in a temporary location first.
+    digests = compute_digests("artifact.bin")
+    print(digests)
+```
+
+Persist the resulting dictionary to your preferred storage medium or reuse the
+CLI JSON file for annex submissions.
+
+## Suggested Checklist
+
+1. Generate or receive the artifact you plan to seal.
+2. Run `verify_hashes.py` and confirm the printed digests.
+3. Attach the JSON sidecar to your annex ledger entry or storage medium.
+4. Include the digests in your BangCheck block when courtesy hashes are
+   required.
+
+Following this checklist ensures downstream verifiers can reproduce the courtesy
+hashes without recalculating them manually.


### PR DESCRIPTION
## Summary
- add a dedicated hash verification guide for the courtesy digest helper script
- link the README usage section to the new guide for easier discovery

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68e382dbd638832db0bcab84a8c2f412