### PR TITLE
Update contact references to new privacy-enabled domain

### DIFF
--- a/Cosmic_Seal_Protocol_Light_Saros_PHS.html
+++ b/Cosmic_Seal_Protocol_Light_Saros_PHS.html
@@ -165,7 +165,7 @@
     <pre id="ex"></pre>
   </section>
 </main>
-<footer><div class="wrap"><span>Updated 2025-09-09 23:30 UTC</span> — host this page at matthewlabarre.com</div></footer>
+<footer><div class="wrap"><span>Updated 2025-09-09 23:30 UTC</span> — host this page at matthewlabarreaol.com (privacy enabled)</div></footer>
 <script>
 // Example JSON display
 const ex = {

--- a/LICENSE
+++ b/LICENSE
@@ -8,7 +8,7 @@ This repository is multi-licensed. By using or copying this repository, you agre
 
 - The logos and seal artwork (under `assets/seals/` and elsewhere) are licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0) license.
 
-For questions regarding alternative licensing, please contact emailme@matthewlabarre.com.
+For questions regarding alternative licensing, please reach out via the privacy-enabled contact form at https://matthewlabarreaol.com.
 
 ----
 

--- a/docs/SEALING_INSTRUCTIONS.md
+++ b/docs/SEALING_INSTRUCTIONS.md
@@ -1,6 +1,6 @@
 # Sealing Instructions
 
-This document provides a step‑by‑step guide for generating **Cosmic Seal Layer** (CSL) records.  It emphasises accessibility and reproducibility.  All seals are **protocol‑only** unless otherwise specified: the BangCheck block contains no cryptographic digests, leaving those values to optional sidecars.  These instructions assume you are using the [Cosmic Sealer web app](https://matthewlabarre.com) or an equivalent client to generate seals.
+This document provides a step‑by‑step guide for generating **Cosmic Seal Layer** (CSL) records.  It emphasises accessibility and reproducibility.  All seals are **protocol‑only** unless otherwise specified: the BangCheck block contains no cryptographic digests, leaving those values to optional sidecars.  These instructions assume you are using the [Cosmic Sealer web app](https://matthewlabarreaol.com) or an equivalent client to generate seals.  The new host enables privacy controls for direct contact with the maintainer.
 
 ## 1. Prepare your artifact
 

--- a/release.json
+++ b/release.json
@@ -2,8 +2,8 @@
   "name": "CSP v1.1 (arXiv v1)",
   "released": "2025-09-08T00:00:00Z",
   "steward": "MATTHEW RUSSELL LABARRE",
-  "contact": "emailme@matthewlabarre.com",
-  "canonical": "https://matthewlabarre.com",
+  "contact": "https://matthewlabarreaol.com",
+  "canonical": "https://matthewlabarreaol.com",
   "artifacts": [
     {
       "name": "csp_arxiv_v1.1.tex",


### PR DESCRIPTION
## Summary
- point the documentation and HTML footer to the new matthewlabarreaol.com host with a privacy note
- replace the licensing contact email with the privacy-enabled contact form link
- update release metadata so canonical and contact fields reference matthewlabarreaol.com

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e4a52adaec832d9f3af51178542b83